### PR TITLE
Implemented @Secured\LoginRedirect annotation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,30 @@ Combination of above two - access is granted only if role have `resource: privil
 #### `@Secured\Role`
 Grand access only to specified `role`.
 
+#### `@Secured\LoginRedirect`
+Redirect to login page if role is not allowed
+You have to setup your `$loginUrl` in your `BasePresenter` for example:
+
+```php
+**
+ * Base presenter for all application presenters.
+ */
+abstract class BasePresenter extends Nette\Application\UI\Presenter
+{
+	/** @var string $loginUrl */
+	public $loginUrl = ':Auth:Login:';
+```
+
+Or if you use `decorator` set-up your `$loginUrl` via `decorator`:
+
+```
+decorator:
+  App\Presenters\BasePresenter:
+    setup:
+      - $loginUrl(%loginUrl%)
+```
+
+
 On every place where `*_NAME` applies, you can specify multiple names separated by comma.
 
 ### Using in presenters, components, models, etc.

--- a/src/IPub/Security/Access/AnnotationChecker.php
+++ b/src/IPub/Security/Access/AnnotationChecker.php
@@ -183,6 +183,17 @@ class AnnotationChecker extends Nette\Object implements IChecker, ICheckRequirem
 		return TRUE;
 	}
 
+
+	/**
+	 * @param \Reflector $element
+	 * @return bool
+	 */
+	public function checkLoginRedirect(\Reflector $element)
+	{
+		return $element->hasAnnotation('Secured\LoginRedirect') ? TRUE : FALSE;
+	}
+
+
 	/**
 	 * @param \Reflector $element
 	 *

--- a/src/IPub/Security/TPermission.php
+++ b/src/IPub/Security/TPermission.php
@@ -32,16 +32,22 @@ trait TPermission
 	 */
 	protected $requirementsChecker;
 
+	/** @var Security\Access\AnnotationChecker $annotationChecker */
+	protected $annotationChecker;
+
 	/**
-	 * @param Security\Permission $permission
+	 * @param Permission $permission
 	 * @param Access\ICheckRequirements $requirementsChecker
+	 * @param Access\AnnotationChecker $annotationChecker
 	 */
 	public function injectPermission(
 		Security\Permission $permission,
-		Access\ICheckRequirements $requirementsChecker
+		Access\ICheckRequirements $requirementsChecker,
+		Security\Access\AnnotationChecker $annotationChecker
 	) {
 		$this->permission			= $permission;
 		$this->requirementsChecker	= $requirementsChecker;
+		$this->annotationChecker    = $annotationChecker;
 	}
 
 	/**
@@ -52,6 +58,10 @@ trait TPermission
 	public function checkRequirements($element)
 	{
 		parent::checkRequirements($element);
+		
+		if (!$this->requirementsChecker->isAllowed($element) && $this->annotationChecker->checkLoginRedirect($element)) {
+			$this->presenter->redirect($this->presenter->loginUrl);
+		}
 
 		if (!$this->requirementsChecker->isAllowed($element)) {
 			throw new Application\ForbiddenRequestException;

--- a/tests/IPubTests/Security/AnnotationsTest.phpt
+++ b/tests/IPubTests/Security/AnnotationsTest.phpt
@@ -234,6 +234,33 @@ class AnnotationsTest extends Tester\TestCase
 		Assert::true($response instanceof Application\Responses\TextResponse);
 		Assert::equal('Passed', $response->getSource());
 	}
+
+
+    /**
+     * @dataProvider dataRegisteredUsers
+     *
+     * @param string $username
+     * @param string $password
+     */
+	public function checkLoginRedirect($username, $password)
+	{
+	    // Create test presenter
+        $presenter = $this->createPresenter();
+
+       	// Try to login user
+        $this->user->login($username, $password);
+
+        // Create GET request
+        $request = new Application\Request('Test', 'GET', array('action' => 'redirect'));
+        // & fire presenter & catch response
+        $response = $presenter->run($request);
+
+        // Logout user
+        $this->user->logout(TRUE);
+
+        Assert::true($response instanceof Application\Responses\TextResponse);
+        Assert::equal('Passed', $response->getSource());
+	}
 }
 
 
@@ -241,6 +268,7 @@ class TestPresenter extends UI\Presenter
 {
 	use Security\TPermission;
 
+    public $loginUrl = 'Test:login';
 
 	/**
 	 * @Secured
@@ -280,6 +308,22 @@ class TestPresenter extends UI\Presenter
 	public function renderRole()
 	{
 		$this->sendResponse(new Application\Responses\TextResponse('Passed'));
+	}
+
+
+	/**
+	* @Secured
+	* @Secured\LoginRedirect
+	*/
+	public function renderRedirect()
+	{
+		$this->sendResponse(new Application\Responses\TextResponse('Passed'));
+	}
+
+
+	public function renderLogin()
+	{
+        $this->sendResponse(new Application\Responses\TextResponse('Passed'));
 	}
 }
 


### PR DESCRIPTION
If user is not allowed by `$requirementsChecker` and annotation `@Secured\LoginRedirect` is activated, user will be redirected to $loginUrl which is defined in `BasePresenter`
